### PR TITLE
a little bit change in auto vote skip

### DIFF
--- a/amqMegaCommands.user.js
+++ b/amqMegaCommands.user.js
@@ -684,7 +684,7 @@ function setup() {
             quiz.answerInput.setNewAnswer(data.answer);
             quiz.answerInput.typingInput.$input.val(currentText);
         }
-        if (autoVoteSkip === "valid" && !quiz.skipController._toggled && animeListLower.includes(data.answer.toLowerCase())) {
+        if (autoVoteSkip === "valid" && !quiz.skipController._toggled && animeListLower.includes(data.answer.toLowerCase()) && (data.answer.length > 1)) {
             quiz.skipClicked();
         }
     }).bindListener();


### PR DESCRIPTION
when in autokey mode in team, sometimes it auto skip when type "K" or "F" (that are valid answers) it'll skip
so i added when answer's length <= 1 it won't auto skip